### PR TITLE
Build ESP-WROOM-32 firmware

### DIFF
--- a/.github/workflows/wled-compile.yaml
+++ b/.github/workflows/wled-compile.yaml
@@ -27,10 +27,10 @@ jobs:
         find /tmp/WLEDtemp -maxdepth 1 -mindepth 1 -name "*" -type d >> /tmp/WLEDtemp/wledfoldername
         cd `cat /tmp/WLEDtemp/wledfoldername`
         echo '[env:custom_build]' >>platformio.ini
-        echo 'extends = env:esp32s3dev_8MB_PSRAM' >>platformio.ini
-        echo 'build_flags = ${env:esp32s3dev_8MB_PSRAM.build_flags} -D WLED_DISABLE_BROWNOUT_DET -D LEDPIN=16 -D USERMOD_DHT -D USERMOD_DHT_CELSIUS -D USERMOD_FOUR_LINE_DISPLAY -D USERMOD_PING_PONG_CLOCK -D USERMOD_WORDCLOCK -D USERMOD_ANALOG_CLOCK' >>platformio.ini
+        echo 'extends = env:esp32dev' >>platformio.ini
+        echo 'build_flags = ${env:esp32dev.build_flags} -D WLED_DISABLE_BROWNOUT_DET -D LEDPIN=16 -D USERMOD_DHT -D USERMOD_DHT_CELSIUS -D USERMOD_FOUR_LINE_DISPLAY -D USERMOD_PING_PONG_CLOCK -D USERMOD_WORDCLOCK -D USERMOD_ANALOG_CLOCK' >>platformio.ini
         echo 'lib_deps = ' >>platformio.ini
-        echo '  ${env:esp32s3dev_8MB_PSRAM.lib_deps}' >>platformio.ini
+        echo '  ${env:esp32dev.lib_deps}' >>platformio.ini
         echo '  https://github.com/alwynallan/DHT_nonblocking' >>platformio.ini
         echo '  olikraus/U8g2 @ ^2.28.8' >>platformio.ini
         


### PR DESCRIPTION
## Summary
- target esp32dev environment for ESP-WROOM-32 in workflow

## Testing
- `yamllint -d '{rules: {document-start: disable, truthy: disable, line-length: disable}}' .github/workflows/wled-compile.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689556e4f72083328721cc7fa3027ebf