### PR TITLE
Build ESP-WROOM-32 firmware

### DIFF
--- a/.github/workflows/wled-compile.yaml
+++ b/.github/workflows/wled-compile.yaml
@@ -26,11 +26,12 @@ jobs:
         unzip /tmp/WLEDtemp/mm.zip -d /tmp/WLEDtemp
         find /tmp/WLEDtemp -maxdepth 1 -mindepth 1 -name "*" -type d >> /tmp/WLEDtemp/wledfoldername
         cd `cat /tmp/WLEDtemp/wledfoldername`
+        cp $GITHUB_WORKSPACE/sdkconfig.h .
         echo '[env:custom_build]' >>platformio.ini
-        echo 'extends = env:esp32s3dev_8MB_PSRAM' >>platformio.ini
-        echo 'build_flags = ${env:esp32s3dev_8MB_PSRAM.build_flags} -D WLED_DISABLE_BROWNOUT_DET -D LEDPIN=16 -D USERMOD_DHT -D USERMOD_DHT_CELSIUS -D USERMOD_FOUR_LINE_DISPLAY -D USERMOD_PING_PONG_CLOCK -D USERMOD_WORDCLOCK -D USERMOD_ANALOG_CLOCK' >>platformio.ini
+        echo 'extends = env:esp32dev' >>platformio.ini
+        echo 'build_flags = ${env:esp32dev.build_flags} -I. -D WLED_DISABLE_BROWNOUT_DET -D LEDPIN=16 -D USERMOD_DHT -D USERMOD_DHT_CELSIUS -D USERMOD_FOUR_LINE_DISPLAY -D USERMOD_PING_PONG_CLOCK -D USERMOD_WORDCLOCK -D USERMOD_ANALOG_CLOCK' >>platformio.ini
         echo 'lib_deps = ' >>platformio.ini
-        echo '  ${env:esp32s3dev_8MB_PSRAM.lib_deps}' >>platformio.ini
+        echo '  ${env:esp32dev.lib_deps}' >>platformio.ini
         echo '  https://github.com/alwynallan/DHT_nonblocking' >>platformio.ini
         echo '  olikraus/U8g2 @ ^2.28.8' >>platformio.ini
         

--- a/sdkconfig.h
+++ b/sdkconfig.h
@@ -1,0 +1,3 @@
+#pragma once
+// Dummy SDK configuration for ESP-WROOM-32 builds
+#define CONFIG_IDF_TARGET_ESP32 1


### PR DESCRIPTION
## Summary
- target esp32dev environment for ESP-WROOM-32 in workflow
- add dummy `sdkconfig.h` for ESP32 builds and include it during compilation

## Testing
- `yamllint -d '{rules: {document-start: disable, truthy: disable, line-length: disable}}' .github/workflows/wled-compile.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689556e4f72083328721cc7fa3027ebf